### PR TITLE
Add 18.6.1, 18.6.2, 18.6.3

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,11 @@
 ---
 galaxy_info:
-    author: "Ryan Speelman"
+    author: "Mark Bolwell, George Nalen"
     description: "Ansible role to apply Windows Server 2022 CIS Benchmark"
     company: "MindPoint Group"
     license: MIT
     role_name: windows_2022_cis
-    min_ansible_version: "2.6"
+    min_ansible_version: "2.9"
     platforms:
         - name: Windows
           versions:

--- a/tasks/section18.yml
+++ b/tasks/section18.yml
@@ -730,6 +730,48 @@
       - rule_18.5.21.2
       - patch
 
+- name: "18.6.1 | PATCH | Ensure 'Allow Print Spooler to accept client connections' is set to 'Disabled'"
+  win_regedit:
+      path: HKLM:\Software\Policies\Microsoft\Windows NT\Printers
+      name: RegisterSpoolerRemoteRpcEndPoint
+      data: 2
+      type: dword
+  when:
+      - rule_18_6_1
+  tags:
+      - level1-domaincontroller
+      - level2-memberserver
+      - rule_18.6.1
+      - patch
+
+- name: "18.6.2 | PATCH | Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt'"
+  win_regedit:
+      path: HKLM:\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint
+      name: NoWarningNoElevationOnInstall
+      data: 0
+      type: dword 
+  when:
+      - rule_18_6_2
+  tags:
+      - level1-memberserver
+      - level1-domaincontroller
+      - rule_18.6.2
+      - patch
+
+- name: "18.6.3 | PATCH | (L1) Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'"
+  win_regedit:
+      path: HKLM:\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint
+      name: UpdatePromptSettings
+      data: 0
+      type: dword
+  when:
+      - rule_18_6_3
+  tags:
+      - level1-memberserver
+      - level1-domaincontroller
+      - rule_18.6.3
+      - patch
+
 - name: "18.7.1.1 | PATCH | Ensure Turn off notifications network usage is set to Enabled"
   win_regedit:
       path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications


### PR DESCRIPTION
Included 18.6.1, 18.6.2, 18.6.3 which are recommendations for printer settings.

# Overall Review of Changes

Included 3 tasks for section containing recommendations for printer settings present under '18.6 Printers' for CIS Microsoft Windows Server 2022 Benchmark.
18.6.1 (L1) Ensure 'Allow Print Spooler to accept client connections' is set to 'Disabled' (Automated)
18.6.2 (L1) Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt' 
18.6.3 (L1) Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'

## Issue Fixes

Please list (using linking) any open issues this PR addresses

## Enhancements

Please list any enhancements/features that are not open issue tickets

## How has this been tested?

N/A

Signed-off-by: Anvay Singh <anvaysingh05@gmail.com>