### PR TITLE
Fix task order for lockout policy

### DIFF
--- a/tasks/section01.yml
+++ b/tasks/section01.yml
@@ -113,7 +113,21 @@
       - rule_1.2.2
       - automated
       - account
-
+      
+- name: "1.2.3 | PATCH | Ensure Reset account lockout counter after is set to 15 or more minutes"
+  ansible.builtin.win_security_policy:
+      section: System Access
+      key: ResetLockoutCount
+      value: "{{ win22cis_resetlockoutcount }}"
+  when:
+      - rule_1_2_3
+  tags:
+      - level1-domaincontroller
+      - level1-memberserver
+      - rule_1.2.3
+      - automated
+      - account
+      
 # Speelman | added because of this error "Failed to import secedit.ini file from C:\\Users\\vagrant\\AppData\\Local\\Temp\\tmp81F3.tmp
 - name: "1.2.1 | AUDIT | Ensure Account lockout duration is set to 15 or more minutes"
   ansible.builtin.win_security_policy:
@@ -129,16 +143,4 @@
       - automated
       - account
 
-- name: "1.2.3 | PATCH | Ensure Reset account lockout counter after is set to 15 or more minutes"
-  ansible.builtin.win_security_policy:
-      section: System Access
-      key: ResetLockoutCount
-      value: "{{ win22cis_resetlockoutcount }}"
-  when:
-      - rule_1_2_3
-  tags:
-      - level1-domaincontroller
-      - level1-memberserver
-      - rule_1.2.3
-      - automated
-      - account
+


### PR DESCRIPTION
In windows server 2022, the default values for LockoutDuration and ResetLockoutCount are 30. 

Setting lockout duration to a value lower than ResetLockoutCount will result in "Failed to import secedit.ini file from C:\\TEMP\\tmpxxxx.tmp" and "The parameter is incorrect" errors. (default applied here is 15)

This brings Windows-2022-CIS inline with the order of Windows-2019-CIS which sets ResetLockoutCount first, then LockoutDuration.

See this resolved issue: https://github.com/ansible/ansible/issues/62594

# Overall Review of Changes

A general description of the changes made that are being requested for merge

## Issue Fixes

Please list (using linking) any open issues this PR addresses

## Enhancements

Please list any enhancements/features that are not open issue tickets

## How has this been tested?

Please give an overview of how these changes were tested. If they were not please use N/A
