### PR TITLE
Only applies to Azure

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -30,6 +30,7 @@
   ansible.builtin.set_fact:
       win22cis_cloud_based_system: true
   when:
+      - ansible_system_vendor == 'Microsoft Corporation'
       - ansible_virtualization_type == 'Hyper-V' or
         ansible_virtualization_type == 'hvm' or
         ansible_virtualization_type == 'kvm'


### PR DESCRIPTION
**Overall Review of Changes:**
Alternate ordering of section 01 controls only applies to Azure, this cloud detection only checks for Azure Virtual Machines right now.

**Issue Fixes:**
#33
 
**Enhancements:**
None

**How has this been tested?:**
I tested from the repo/branch from this PR

Results:
```
TASK [Windows-2022-CIS : 1.2.2 | PATCH | Ensure Account lockout threshold is set to 5 or fewer invalid logon attempt(s), but not 0. | Set Variable.] ***
changed: [10.0.0.3]

TASK [Windows-2022-CIS : 1.2.3 | PATCH | Ensure Allow Administrator account lockout is set to Enabled] ***
changed: [10.0.0.3]

TASK [Windows-2022-CIS : 1.2.4 | PATCH | Ensure Reset account lockout counter after is set to 15 or more minutes. | Set Variable.] ***
changed: [10.0.0.3]

TASK [Windows-2022-CIS : 1.2.1 | PATCH | Ensure Account lockout duration is set to 15 or more minutes. | Set Variable] ***
changed: [10.0.0.3]
```
