### PR TITLE
Fix 18.10.82.1

### DIFF
--- a/tasks/section18.yml
+++ b/tasks/section18.yml
@@ -3454,7 +3454,7 @@
   ansible.windows.win_regedit:
       path: HKLM:\Software\Microsoft\Windows\Currentversion\Policies\System
       name: EnableMPR
-      data: 1
+      data: 0
       type: dword
   when:
       - win22cis_rule_18_10_82_1


### PR DESCRIPTION
**Overall Review of Changes:**
The registry key associated with control "18.10.82.1 Ensure 'Enable MPR notifications for the system' is set to 'Disabled'" is incorrectly configured. It should have a value of 0 to indicate the disabled state

**Issue Fixes:**
N/A

**Enhancements:**
The value for EnableMPR was adjusted from 1 to 0 to ensure compliance.

**How has this been tested?:**
Tested on a Windows 11 23H2 VM, since it has the new admx files, according to [Microsoft Tech Community](https://techcommunity.microsoft.com/t5/microsoft-security-baselines/windows-11-version-22h2-security-baseline/ba-p/3632520). Enabled the policy setting to disabled state, resulting in the creation of the registry key with a value of 0.

Added the key manually on a hardened Windows Server 2022 test VM. Then verified the control in Rapid7 InightVM which resulted in a pass.

```
oval-org.cisecurity.benchmarks.microsoft_windows_server_2022-def-3607688: PASS

Based on the following 1 results:

At least one specified Windows registry information entry must match the given criteria. At least one evaluation must pass.

Entry 1 findings: PASS
hive: HKEY_LOCAL_MACHINE
key: SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
name: EnableMPR
type: reg_dword
value: 0
```